### PR TITLE
feat: spread BottomNav across Home, Harmony, Care, and Wonder screens (Issue #42)

### DIFF
--- a/src/tests/screens/CareScreen.test.tsx
+++ b/src/tests/screens/CareScreen.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { ThemeProvider } from '@rneui/themed';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components/native';
+import CareScreen from '../../screens/CareScreen';
+import { rneThemeBase, theme } from '../../styles/theme';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RouteProp } from '@react-navigation/native';
+import { RootStackParamList } from '../../navigation/AppNavigator';
+import { DefaultTheme } from 'styled-components/native';
+
+describe('CareScreen', () => {
+  const mockNavigation: StackNavigationProp<RootStackParamList, 'Care'> = {
+    navigate: jest.fn(),
+    getState: jest.fn(),
+    dispatch: jest.fn(),
+    addListener: jest.fn(() => () => {}),
+    canGoBack: jest.fn(),
+    getId: jest.fn(),
+    getParent: jest.fn(),
+    goBack: jest.fn(),
+    isFocused: jest.fn(),
+    removeListener: jest.fn(),
+    reset: jest.fn(),
+    setOptions: jest.fn(),
+    setParams: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    pop: jest.fn(),
+    popTo: jest.fn(),
+    popToTop: jest.fn(),
+    navigateDeprecated: jest.fn(),
+    preload: jest.fn(),
+    setStateForNextRouteNamesChange: jest.fn(),
+  };
+
+  const mockRoute: RouteProp<RootStackParamList, 'Care'> = {
+    key: 'Care-123',
+    name: 'Care',
+    params: undefined,
+  };
+
+  const renderWithNavigation = () =>
+    render(
+      <ThemeProvider theme={rneThemeBase}>
+        <StyledThemeProvider theme={theme as DefaultTheme}>
+          <NavigationContainer>
+            <CareScreen navigation={mockNavigation} route={mockRoute} />
+          </NavigationContainer>
+        </StyledThemeProvider>
+      </ThemeProvider>
+    );
+
+  it('renders BottomNav with all icons', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      expect(getByTestId('bottom-nav-home')).toBeTruthy();
+      expect(getByTestId('bottom-nav-harmony')).toBeTruthy();
+      expect(getByTestId('bottom-nav-care')).toBeTruthy();
+      expect(getByTestId('bottom-nav-wonder')).toBeTruthy();
+    });
+  });
+
+  it('highlights Care icon as active', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      const careIcon = getByTestId('bottom-nav-care').children[0];
+      expect(careIcon.props.style).toMatchObject({ tintColor: theme.colors.background });
+      const homeIcon = getByTestId('bottom-nav-home').children[0];
+      expect(homeIcon.props.style).toMatchObject({ tintColor: theme.colors.primary });
+    });
+  });
+
+  it('navigates to Home when Home icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-home'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Home');
+    });
+  });
+
+  it('navigates to Harmony when Harmony icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-harmony'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Harmony');
+    });
+  });
+
+  it('navigates to Wonder when Wonder icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-wonder'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Wonder');
+    });
+  });
+});

--- a/src/tests/screens/HarmonyScreen.test.tsx
+++ b/src/tests/screens/HarmonyScreen.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { ThemeProvider } from '@rneui/themed';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components/native';
+import HarmonyScreen from '../../screens/HarmonyScreen';
+import { rneThemeBase, theme } from '../../styles/theme';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RouteProp } from '@react-navigation/native';
+import { RootStackParamList } from '../../navigation/AppNavigator';
+import { DefaultTheme } from 'styled-components/native';
+
+describe('HarmonyScreen', () => {
+  const mockNavigation: StackNavigationProp<RootStackParamList, 'Harmony'> = {
+    navigate: jest.fn(),
+    getState: jest.fn(),
+    dispatch: jest.fn(),
+    addListener: jest.fn(() => () => {}),
+    canGoBack: jest.fn(),
+    getId: jest.fn(),
+    getParent: jest.fn(),
+    goBack: jest.fn(),
+    isFocused: jest.fn(),
+    removeListener: jest.fn(),
+    reset: jest.fn(),
+    setOptions: jest.fn(),
+    setParams: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    pop: jest.fn(),
+    popTo: jest.fn(),
+    popToTop: jest.fn(),
+    navigateDeprecated: jest.fn(),
+    preload: jest.fn(),
+    setStateForNextRouteNamesChange: jest.fn(),
+  };
+
+  const mockRoute: RouteProp<RootStackParamList, 'Harmony'> = {
+    key: 'Harmony-123',
+    name: 'Harmony',
+    params: undefined,
+  };
+
+  const renderWithNavigation = () =>
+    render(
+      <ThemeProvider theme={rneThemeBase}>
+        <StyledThemeProvider theme={theme as DefaultTheme}>
+          <NavigationContainer>
+            <HarmonyScreen navigation={mockNavigation} route={mockRoute} />
+          </NavigationContainer>
+        </StyledThemeProvider>
+      </ThemeProvider>
+    );
+
+  it('renders BottomNav with all icons', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      expect(getByTestId('bottom-nav-home')).toBeTruthy();
+      expect(getByTestId('bottom-nav-harmony')).toBeTruthy();
+      expect(getByTestId('bottom-nav-care')).toBeTruthy();
+      expect(getByTestId('bottom-nav-wonder')).toBeTruthy();
+    });
+  });
+
+  it('highlights Harmony icon as active', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      const harmonyIcon = getByTestId('bottom-nav-harmony').children[0];
+      expect(harmonyIcon.props.style).toMatchObject({ tintColor: theme.colors.background });
+      const homeIcon = getByTestId('bottom-nav-home').children[0];
+      expect(homeIcon.props.style).toMatchObject({ tintColor: theme.colors.primary });
+    });
+  });
+
+  it('navigates to Home when Home icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-home'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Home');
+    });
+  });
+
+  it('navigates to Care when Care icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-care'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Care');
+    });
+  });
+
+  it('navigates to Wonder when Wonder icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-wonder'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Wonder');
+    });
+  });
+});

--- a/src/tests/screens/HomeScreen.test.tsx
+++ b/src/tests/screens/HomeScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { ThemeProvider } from '@rneui/themed';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components/native';
@@ -28,7 +28,7 @@ describe('HomeScreen', () => {
     push: jest.fn(),
     replace: jest.fn(),
     pop: jest.fn(),
-    popTo: jest.fn(), // Added
+    popTo: jest.fn(),
     popToTop: jest.fn(),
     navigateDeprecated: jest.fn(),
     preload: jest.fn(),
@@ -93,13 +93,47 @@ describe('HomeScreen', () => {
     });
   });
 
-  it('renders bottom nav with all icons', async () => {
+  it('renders BottomNav with all icons', async () => {
     const { getByTestId } = renderWithNavigation();
     await waitFor(() => {
       expect(getByTestId('bottom-nav-home')).toBeTruthy();
       expect(getByTestId('bottom-nav-harmony')).toBeTruthy();
       expect(getByTestId('bottom-nav-care')).toBeTruthy();
       expect(getByTestId('bottom-nav-wonder')).toBeTruthy();
+    });
+  });
+
+  it('highlights Home icon as active', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      const homeIcon = getByTestId('bottom-nav-home').children[0]; // Image is direct child
+      expect(homeIcon.props.style).toMatchObject({ tintColor: theme.colors.background });
+      const harmonyIcon = getByTestId('bottom-nav-harmony').children[0];
+      expect(harmonyIcon.props.style).toMatchObject({ tintColor: theme.colors.primary });
+    });
+  });
+
+  it('navigates to Harmony when Harmony icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-harmony'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Harmony');
+    });
+  });
+
+  it('navigates to Care when Care icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-care'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Care');
+    });
+  });
+
+  it('navigates to Wonder when Wonder icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-wonder'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Wonder');
     });
   });
 });

--- a/src/tests/screens/WonderScreen.test.tsx
+++ b/src/tests/screens/WonderScreen.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { ThemeProvider } from '@rneui/themed';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components/native';
+import WonderScreen from '../../screens/WonderScreen';
+import { rneThemeBase, theme } from '../../styles/theme';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RouteProp } from '@react-navigation/native';
+import { RootStackParamList } from '../../navigation/AppNavigator';
+import { DefaultTheme } from 'styled-components/native';
+
+describe('WonderScreen', () => {
+  const mockNavigation: StackNavigationProp<RootStackParamList, 'Wonder'> = {
+    navigate: jest.fn(),
+    getState: jest.fn(),
+    dispatch: jest.fn(),
+    addListener: jest.fn(() => () => {}),
+    canGoBack: jest.fn(),
+    getId: jest.fn(),
+    getParent: jest.fn(),
+    goBack: jest.fn(),
+    isFocused: jest.fn(),
+    removeListener: jest.fn(),
+    reset: jest.fn(),
+    setOptions: jest.fn(),
+    setParams: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    pop: jest.fn(),
+    popTo: jest.fn(),
+    popToTop: jest.fn(),
+    navigateDeprecated: jest.fn(),
+    preload: jest.fn(),
+    setStateForNextRouteNamesChange: jest.fn(),
+  };
+
+  const mockRoute: RouteProp<RootStackParamList, 'Wonder'> = {
+    key: 'Wonder-123',
+    name: 'Wonder',
+    params: undefined,
+  };
+
+  const renderWithNavigation = () =>
+    render(
+      <ThemeProvider theme={rneThemeBase}>
+        <StyledThemeProvider theme={theme as DefaultTheme}>
+          <NavigationContainer>
+            <WonderScreen navigation={mockNavigation} route={mockRoute} />
+          </NavigationContainer>
+        </StyledThemeProvider>
+      </ThemeProvider>
+    );
+
+  it('renders BottomNav with all icons', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      expect(getByTestId('bottom-nav-home')).toBeTruthy();
+      expect(getByTestId('bottom-nav-harmony')).toBeTruthy();
+      expect(getByTestId('bottom-nav-care')).toBeTruthy();
+      expect(getByTestId('bottom-nav-wonder')).toBeTruthy();
+    });
+  });
+
+  it('highlights Wonder icon as active', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      const wonderIcon = getByTestId('bottom-nav-wonder').children[0];
+      expect(wonderIcon.props.style).toMatchObject({ tintColor: theme.colors.background });
+      const homeIcon = getByTestId('bottom-nav-home').children[0];
+      expect(homeIcon.props.style).toMatchObject({ tintColor: theme.colors.primary });
+    });
+  });
+
+  it('navigates to Home when Home icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-home'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Home');
+    });
+  });
+
+  it('navigates to Harmony when Harmony icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-harmony'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Harmony');
+    });
+  });
+
+  it('navigates to Care when Care icon is pressed', async () => {
+    const { getByTestId } = renderWithNavigation();
+    await waitFor(() => {
+      fireEvent.press(getByTestId('bottom-nav-care'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Care');
+    });
+  });
+});


### PR DESCRIPTION
Extracted BottomNav into a reusable component with useTheme and style prop transform [{ translateX: -50 }]. Applied to HomeScreen, HarmonyScreen, CareScreen, and WonderScreen. Fixed tests to use children array for styled-components. All tests pass, Android rendering and navigation confirmed. Closes #42.