### PR TITLE
feat: add reusable Card component with tests (Issue #58)

### DIFF
--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { ImageSourcePropType, TouchableOpacity } from 'react-native';
+import styled, { useTheme } from 'styled-components/native';
+import { DefaultTheme } from 'styled-components/native';
+
+const CardWrapper = styled(TouchableOpacity)`
+  width: ${({ theme }: { theme: DefaultTheme }) => theme.sizes.cardWidth}px;
+  height: ${({ theme }: { theme: DefaultTheme }) => theme.sizes.cardHeight}px;
+  margin-vertical: ${({ theme }: { theme: DefaultTheme }) => theme.spacing.medium}px;
+  border-radius: 25px;
+  overflow: hidden;
+`;
+
+const BackgroundImage = styled.ImageBackground`
+  flex: 1;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+`;
+
+const ContentContainer = styled.View`
+  flex: 1;
+  justify-content: space-between;
+`;
+
+const TextContainer = styled.View`
+  margin: ${({ theme }: { theme: DefaultTheme }) => theme.spacing.large}px;
+`;
+
+const Title = styled.Text`
+  font-size: ${({ theme }: { theme: DefaultTheme }) => theme.fonts.sizes.title}px;
+  color: ${({ theme }: { theme: DefaultTheme }) => theme.colors.contrastText};
+  font-family: ${({ theme }: { theme: DefaultTheme }) => theme.fonts.regular};
+  text-align: left;
+`;
+
+const Subtext = styled.Text`
+  font-size: ${({ theme }: { theme: DefaultTheme }) => theme.fonts.sizes.body}px;
+  color: ${({ theme }: { theme: DefaultTheme }) => theme.colors.contrastText};
+  font-family: ${({ theme }: { theme: DefaultTheme }) => theme.fonts.regular};
+  text-align: left;
+`;
+
+const BadgeContainer = styled.View`
+  align-self: flex-end;
+  margin-right: 10px;
+`;
+
+const Badge = styled.Text`
+  font-size: ${({ theme }: { theme: DefaultTheme }) => theme.fonts.sizes.small}px;
+  color: ${({ theme }: { theme: DefaultTheme }) => theme.colors.contrastText};
+  background-color: ${({ theme }: { theme: DefaultTheme }) => theme.colors.muted};
+  padding: ${({ theme }: { theme: DefaultTheme }) => theme.spacing.xsmall}px ${({ theme }: { theme: DefaultTheme }) => theme.spacing.medium}px;
+  border-radius: 12px;
+  margin-top: ${({ theme }: { theme: DefaultTheme }) => theme.spacing.xsmall}px;
+  text-align: center;
+`;
+
+const IconContainer = styled.View`
+  align-self: flex-end;
+  margin-right: ${({ theme }: { theme: DefaultTheme }) => theme.spacing.medium}px;
+  margin-top: ${({ theme }: { theme: DefaultTheme }) => theme.spacing.small}px;
+`;
+
+const Icon = styled.Image`
+  width: 24px;
+  height: 24px;
+`;
+
+interface CardProps {
+  testID: string;
+  backgroundImage: ImageSourcePropType;
+  title: string;
+  subtext?: string;
+  badges?: string[];
+  icon?: ImageSourcePropType;
+  onPress: () => void;
+}
+
+const Card: React.FC<CardProps> = ({
+  testID,
+  backgroundImage,
+  title,
+  subtext,
+  badges,
+  icon,
+  onPress,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <CardWrapper testID={testID} onPress={onPress}>
+      <BackgroundImage source={backgroundImage} resizeMode="cover" testID={`${testID}-background`}>
+        <ContentContainer>
+          <BadgeContainer>
+            {badges && badges.map((badge, index) => (
+              <Badge key={index}>{badge}</Badge>
+            ))}
+            {icon && (
+              <IconContainer>
+                <Icon source={icon} testID={`${testID}-icon`} />
+              </IconContainer>
+            )}
+          </BadgeContainer>
+          <TextContainer>
+            <Title>{title}</Title>
+            {subtext && <Subtext>{subtext}</Subtext>}
+          </TextContainer>
+        </ContentContainer>
+      </BackgroundImage>
+    </CardWrapper>
+  );
+};
+
+export default Card;

--- a/src/tests/components/Card.test.tsx
+++ b/src/tests/components/Card.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import Card from '../../components/common/Card';
+import { ThemeProvider } from '@rneui/themed';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components/native';
+import { rneThemeBase, theme } from '../../styles/theme';
+
+describe('Card', () => {
+  const renderCard = (props = {}) =>
+    render(
+      <ThemeProvider theme={rneThemeBase}>
+        <StyledThemeProvider theme={theme}>
+          <Card
+            testID="card"
+            backgroundImage={require('../../assets/png/harmony/auroraforestmap.png')}
+            title="Test Card"
+            onPress={jest.fn()}
+            {...props}
+          />
+        </StyledThemeProvider>
+      </ThemeProvider>
+    );
+
+  it('renders with background image and title', () => {
+    const { getByTestId, getByText } = renderCard();
+    expect(getByTestId('card-background')).toBeTruthy();
+    expect(getByText('Test Card')).toBeTruthy();
+  });
+
+  it('calls onPress when clicked', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = renderCard({ onPress });
+    fireEvent.press(getByTestId('card'));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it('renders subtext when provided', () => {
+    const { getByText } = renderCard({ subtext: 'Test Subtext' });
+    expect(getByText('Test Subtext')).toBeTruthy();
+  });
+
+  it('renders badges when provided', () => {
+    const { getByText } = renderCard({ badges: ['Badge1', 'Badge2'] });
+    expect(getByText('Badge1')).toBeTruthy();
+    expect(getByText('Badge2')).toBeTruthy();
+  });
+
+  it('renders icon when provided', () => {
+    const { getByTestId } = renderCard({
+      icon: require('../../assets/png/icons/magnifying-glass.png'),
+    });
+    expect(getByTestId('card-icon')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Created  as a reusable component for consistent card layouts. Supports background images, title/subtext, badges, icons, and onPress handlers. Added TDD via . Next step: refactor screens to use this component. Part of #33, closes #58.