### PR TITLE
feat: add event arcs and radial menu to Care Screen tracker (Issue #72)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'jest-expo',
   testEnvironment: 'jsdom',
-  setupFiles: ['<rootDir>/jest/setup.js'], // Confirms jest/setup.js is used
+  setupFiles: ['<rootDir>/jest/setup.js'],
   setupFilesAfterEnv: ['@testing-library/react-native/extend-expect'],
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', {
@@ -12,7 +12,7 @@ module.exports = {
     '^.+\\.(js|jsx)$': ['babel-jest', { configFile: './.babelrc' }]
   },
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@rneui/.*)'
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@rneui/.*|d3-shape|d3-path)'
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@babel/preset-react": "^7.26.3",
         "@react-native-community/cli": "^18.0.0",
         "@testing-library/react-native": "^12.5.0",
+        "@types/d3-shape": "^3.1.7",
         "@types/firebase": "^2.4.32",
         "@types/invariant": "^2.2.37",
         "@types/jest": "^29.5.14",
@@ -7441,6 +7442,23 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
       }
     },
     "node_modules/@types/eslint": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/preset-react": "^7.26.3",
     "@react-native-community/cli": "^18.0.0",
     "@testing-library/react-native": "^12.5.0",
+    "@types/d3-shape": "^3.1.7",
     "@types/firebase": "^2.4.32",
     "@types/invariant": "^2.2.37",
     "@types/jest": "^29.5.14",

--- a/src/tests/screens/CareScreen.test.tsx
+++ b/src/tests/screens/CareScreen.test.tsx
@@ -100,4 +100,24 @@ describe('CareScreen', () => {
     const minuteTicks = getAllByTestId('minute-tick');
     expect(minuteTicks.length).toBe(48); // 15-minute intervals
   });
+
+  it('logs sleep event arc on radial menu selection', async () => {
+    const { getByTestId } = renderWithNavigation();
+    fireEvent(getByTestId('tracker-ring'), 'longPress');
+    await waitFor(() => expect(getByTestId('radial-menu')).toBeTruthy());
+    fireEvent.press(getByTestId('radial-sleep'));
+    await waitFor(() => {
+      expect(getByTestId('sleep-arc')).toBeTruthy();
+    }, { timeout: 2000 });
+  });
+
+  it('logs diaper event arc on radial menu selection', async () => {
+    const { getByTestId } = renderWithNavigation();
+    fireEvent(getByTestId('tracker-ring'), 'longPress');
+    await waitFor(() => expect(getByTestId('radial-menu')).toBeTruthy());
+    fireEvent.press(getByTestId('radial-diaper'));
+    await waitFor(() => {
+      expect(getByTestId('diaper-arc')).toBeTruthy();
+    }, { timeout: 2000 });
+  });
 });


### PR DESCRIPTION
Added interactive event arcs (feed, sleep, diaper) to the Care Screen tracker using  for arc paths. Implemented a radial menu on long press with options to log events. Updated  and tests in . Fixed ESM issues by adding  and  to Jest transformIgnorePatterns. Closes #72, part of #68.